### PR TITLE
fix moromoro

### DIFF
--- a/solver/google/search/split_agent/split_agent.cpp
+++ b/solver/google/search/split_agent/split_agent.cpp
@@ -24,15 +24,22 @@ void Node::GetKey(const int_fast32_t &team_id) {
 }
 
 int_fast32_t GetBeamWidth(const GameData &game_data,
-						  const int_fast32_t &beam_depth) {
-	const int_fast32_t can_simulate_ps = 400000;
+						  const int_fast32_t &beam_depth,
+						  const bool &first_search,
+						  const bool &rival_team) {
+	const int_fast32_t can_simulate_ps = 1400000;
 	const int_fast32_t one_transition =
 		one_transition_table[game_data.agent_num];
-	const double turn_time = (game_data.turn_time_ms - 2000) / 1000.0;
+	const int_fast32_t make_new_node = first_search ? 500 : 0;
+	const double turn_time = (game_data.turn_time_ms - 2000 - make_new_node) / 1000.0;
 	const double rival_width = 2.0/3.0;
 
-	return (can_simulate_ps * turn_time) /
-		   ((beam_depth - 1) * one_transition * (1.0 + rival_width));
+	double ret_width =
+		(can_simulate_ps * turn_time) /
+		((beam_depth - 1) * one_transition * (1.0 + rival_width));
+	if (rival_team)
+		ret_width *= rival_width;
+	return ret_width;
 }
 
 void EraseRivalAgent(const int_fast32_t &rival_team,
@@ -47,18 +54,28 @@ void EraseRivalAgent(const int_fast32_t &rival_team,
 vector<array<Move, 8>> BeamSearch(const GameData &game_data,
 						  const TurnData &turn_data,
 						  const int_fast32_t &team_id,
-						  const int_fast32_t &ally_team) {
+						  const int_fast32_t &ally_team,
+						  const bool &first_search) {
 	const int_fast32_t beam_depth = 5;
-	const int_fast32_t beam_width = GetBeamWidth(game_data, beam_depth);
-
-	static vector<Node*> now_all_nodes(1<<(9*3), nullptr);
-	static vector<Node*> next_all_nodes(1<<(9*3), nullptr);
+	const int_fast32_t beam_width = GetBeamWidth(game_data, beam_depth,
+												 first_search,
+												 team_id != ally_team);
+	using Node_ptr = Node*;
+	static bool need_create = true;
+	static Node_ptr *now_all_nodes, *next_all_nodes;
+	if (need_create) {
+		need_create = false;
+		int_fast32_t node_size = 1<<(9*3);
+		now_all_nodes = new Node_ptr[node_size];
+		next_all_nodes = new Node_ptr[node_size];
+	}
 	greater_priority_queue<pair<double, int_fast32_t>> now_que, next_que;
 	Node root(turn_data, 0);
 	root.GetKey(team_id);
 	EraseRivalAgent(team_id^1, root.turn_data);
-	if (now_all_nodes[root.key] == nullptr)
+	if (now_all_nodes[root.key] == nullptr) {
 		now_all_nodes[root.key] = new Node();
+	}
 	*now_all_nodes[root.key] = root;
 	now_que.push(make_pair(0, root.key));
 	for (int_fast32_t turn = turn_data.now_turn;
@@ -92,7 +109,8 @@ vector<array<Move, 8>> BeamSearch(const GameData &game_data,
 				next_turn_data.Transition(game_data, check_moves);
 				++next_turn_data.now_turn;
 				sort(next_turn_data.agents_position[team_id].begin(),
-					 next_turn_data.agents_position[team_id].end());
+					 next_turn_data.agents_position[team_id].begin() +
+					 turn_data.agent_num);
 				next_node = Node(next_turn_data,
 								 GetEvaluation(game_data,
 								 			   next_turn_data,
@@ -109,8 +127,9 @@ vector<array<Move, 8>> BeamSearch(const GameData &game_data,
 					next_node.first_move = now_node.first_move;
 				}
 
-				if (next_all_nodes[next_node.key] == nullptr)
-					next_all_nodes[next_node.key] = new Node();
+				if (next_all_nodes[next_node.key] == nullptr) {
+						next_all_nodes[next_node.key] = new Node();
+				}
 				Node &check_node = *next_all_nodes[next_node.key];
 
 				if (check_node.turn_data.now_turn ==
@@ -126,6 +145,9 @@ vector<array<Move, 8>> BeamSearch(const GameData &game_data,
 						next_que.push(make_pair(next_node.evaluation,
 												next_node.key));
 					} else {
+						while (next_que.size() > beam_width) {
+							next_que.pop();
+						}
 						const Node &top_node =
 							*next_all_nodes[next_que.top().second];
 						if (top_node.evaluation > next_que.top().first ||
@@ -139,21 +161,28 @@ vector<array<Move, 8>> BeamSearch(const GameData &game_data,
 				}
 			} while (NextPermutation(all_moves, 0, move_ids, check_moves));
 		}
+		while (next_que.size() > beam_width) {
+			next_que.pop();
+		}
 		swap(now_que, next_que);
 		swap(now_all_nodes, next_all_nodes);
 	}
-
+	const int_fast32_t &ret_size = game_data.agent_num <= 6 ? 100 : 21;
 	vector<array<Move, 8>> ret;
 	set<array<Move, 8>> added;
 	while (now_que.size()) {
-		if (now_que.size() <= (game_data.agent_num <= 6 ? 100 : 21)) {
-			if (added.find(now_all_nodes[now_que.top().second]->first_move) ==
-				added.end()) {
-				ret.push_back(now_all_nodes[now_que.top().second]->first_move);
-				added.insert(now_all_nodes[now_que.top().second]->first_move);
-			}
+		if (added.find(now_all_nodes[now_que.top().second]->first_move) ==
+			added.end()) {
+			ret.push_back(now_all_nodes[now_que.top().second]->first_move);
+			added.insert(now_all_nodes[now_que.top().second]->first_move);
 		}
 		now_que.pop();
+	}
+	if (ret.size() > ret_size) {
+		reverse(ret.begin(), ret.end());
+		while (ret.size() > ret_size) {
+			ret.pop_back();
+		}
 	}
 
 	return ret;
@@ -200,20 +229,23 @@ vector<TurnData> GetSplitTurnData(
 array<vector<vector<int_fast32_t>>, 2> GetTruthIndex(
 		const GameData &game_data, const vector<TurnData> &split_turn_data,
 		const array<array<pair<Position, int_fast32_t>, 8>, 2> &agents_with_id) {
-	const int_fast32_t &split_size = split_table[game_data.agent_num].size();
+	const int_fast32_t &all_agent_num = game_data.agent_num;
+	const int_fast32_t &split_size = split_table[all_agent_num].size();
 	array<vector<vector<int_fast32_t>>, 2> ret;
 	for (int_fast32_t &&team_id = 0; team_id < 2; ++team_id) {
 		ret[team_id].resize(split_size);
 		int_fast32_t before_count = 0;
 		for (int_fast32_t &&split_id = 0; split_id < split_size; ++split_id) {
+			const int_fast32_t &one_size =
+				split_table[all_agent_num][split_id];
+			ret[team_id][split_id].resize(one_size);
 			for (int_fast32_t &&agent_id = 0;
-				 agent_id < split_table[game_data.agent_num][split_id];
-				 ++agent_id) {
+				 agent_id < split_table[all_agent_num][split_id]; ++agent_id) {
 				const int_fast32_t truth_id = before_count + agent_id;
-				ret[team_id][agent_id][split_id] =
+				ret[team_id][split_id][agent_id] =
 					agents_with_id[team_id][truth_id].second;
 			}
-			before_count += split_table[game_data.agent_num][split_id];
+			before_count += one_size;
 		}
 	}
 
@@ -226,12 +258,17 @@ array<vector<vector<array<Move, 8>>>, 2> GetCandidateSplitMoves(
 	const int_fast32_t &split_size = split_table[game_data.agent_num].size();
 	array<vector<vector<array<Move, 8>>>, 2> ret;
 
+	bool first_search = true;
 	for (int_fast32_t &&team_id = 0; team_id < 2; ++team_id) {
-		ret[team_id].resize(split_size);
+		const int_fast32_t &check_team = ally_team^1^team_id;
+		ret[check_team].resize(split_size);
 		for (int_fast32_t &&split_id = 0; split_id < split_size; ++split_id) {
-			ret[team_id][split_id] = BeamSearch(game_data,
-												split_turn_data[split_id],
-												team_id, ally_team);
+			// 探索は敵から
+			ret[check_team][split_id] = BeamSearch(game_data,
+												   split_turn_data[split_id],
+												   check_team, ally_team,
+												   first_search);
+			first_search = false;
 		}
 	}
 
@@ -253,15 +290,16 @@ void RestoreTruthIndex(const vector<int_fast32_t> &truth_id,
 void MakeTrasitionMoves(const GameData &game_data,
 						const vector<array<Move, 8>> &check_split_moves,
 						vector<Move> &check_all_moves) {
-	const int_fast32_t split_size = split_table[game_data.agent_num].size();
+	const int_fast32_t &all_agent_num = game_data.agent_num;
+	const int_fast32_t &split_size = split_table[all_agent_num].size();
 	int_fast32_t &&before_count = 0;
-	for (int_fast32_t &&split_id = 0; split_id < before_count; ++split_id) {
-		for (int_fast32_t &&agent_id = 0;
-			 agent_id < split_table[game_data.agent_num][split_id];
-			 ++agent_id) {
+	for (int_fast32_t &&split_id = 0; split_id < split_size; ++split_id) {
+		const int_fast32_t &one_size = split_table[all_agent_num][split_id];
+		for (int_fast32_t &&agent_id = 0; agent_id < one_size; ++agent_id) {
 			int_fast32_t truth_id = before_count + agent_id;
 			check_all_moves[truth_id] = check_split_moves[split_id][agent_id];
 		}
+		before_count += one_size;
 	}
 
 	return;
@@ -274,7 +312,7 @@ vector<vector<Move>> RivalAllSearch(
 	TurnData now_turn_data = turn_data;
 	EraseRivalAgent(team_id^1, now_turn_data);
 	vector<int_fast32_t> move_ids(split_moves.size(), 0);
-	vector<array<Move, 8>> check_split_moves;
+	vector<array<Move, 8>> check_split_moves(split_moves.size());
 	vector<Node> all_nodes;
 	for (int_fast32_t &&split_id = 0; split_id < split_moves.size();
 		 ++split_id) {
@@ -299,7 +337,6 @@ vector<vector<Move>> RivalAllSearch(
 		}
 		all_nodes.push_back(next_node);
 	} while (NextPermutation(split_moves, 0, move_ids, check_split_moves));
-
 	sort(all_nodes.begin(), all_nodes.end(), greater<>());
 	vector<vector<Move>> ret_moves(10);
 	for (int_fast32_t &&i = 0; i < 10; ++i) {
@@ -308,6 +345,11 @@ vector<vector<Move>> RivalAllSearch(
 			 ++agent_id) {
 			ret_moves[i][agent_id] = all_nodes[i].first_move[agent_id];
 		}
+	}
+
+	if (all_nodes.size() < 10) {
+		while (ret_moves.size() > all_nodes.size())
+			ret_moves.pop_back();
 	}
 
 	return ret_moves;
@@ -319,7 +361,7 @@ array<Move, 8> AllyAllSearch(
 		const vector<vector<Move>> &rival_all_moves,
 		const int_fast32_t &ally_team) {
 	vector<int_fast32_t> move_ids(ally_split_moves.size(), 0);
-	vector<array<Move, 8>> check_split_moves;
+	vector<array<Move, 8>> check_split_moves(ally_split_moves.size());
 	vector<Node> all_nodes;
 	for (int_fast32_t &&split_id = 0; split_id < ally_split_moves.size();
 		 ++split_id) {
@@ -373,7 +415,6 @@ array<Move, 8> SplitSearch(const GameData &game_data,
 	auto candidate_split_moves = GetCandidateSplitMoves(game_data,
 														split_turn_data,
 														ally_team);
-
 	const int_fast32_t &split_size = split_table[game_data.agent_num].size();
 	for (int_fast32_t &&team_id = 0; team_id < 2; ++team_id) {
 		for (int_fast32_t &&split_id = 0; split_id < split_size; ++split_id) {
@@ -389,6 +430,8 @@ array<Move, 8> SplitSearch(const GameData &game_data,
 										  rival_split_moves, ally_team^1);
 	auto ally_all_moves = AllyAllSearch(game_data, turn_data, ally_split_moves,
 										rival_all_moves, ally_team);
+
+	sort(ally_all_moves.begin(), ally_all_moves.begin() + game_data.agent_num);
 
 	return ally_all_moves;
 }

--- a/solver/google/search/split_agent/split_agent.h
+++ b/solver/google/search/split_agent/split_agent.h
@@ -26,12 +26,14 @@ struct Node {
 	};
 };
 
-int_fast32_t GetBeamWidth(const GameData&, const int_fast32_t&);
+int_fast32_t GetBeamWidth(const GameData&, const int_fast32_t&, const bool&,
+						  const bool&);
 
 void EraseRivalAgent(const int_fast32_t&, TurnData&);
 
 vector<array<Move, 8>> BeamSearch(const GameData&, const TurnData&,
-								  const int_fast32_t&, const int_fast32_t&);
+								  const int_fast32_t&, const int_fast32_t&,
+								  const bool&);
 
 array<array<pair<Position, int_fast32_t>, 8>, 2> GetAgentsPositionWidthID(
 		const GameData&, const TurnData&);
@@ -85,7 +87,7 @@ const array<int_fast32_t, 9> one_transition_table = {
 	8*8 + 6*6*6,
 	6*6*6 + 6*6*6,
 	8*8 + 8*8 + 6*6*6,
-	8*8 + 6*6*6 * 6*6*6
+	8*8 + 6*6*6 + 6*6*6
 };
 
 }


### PR DESCRIPTION
split_agent
	GetTruthIndex
		retのresizeが足りてない
		ret[team_id][split_id][agent_id]
	EraseRivalAgent
		敵じゃなくて任意のチームのほうがよさそう
	BeamSearch
		agentのsort.end()しない
		retでいい感じをして制限個数に合わせる
	MakeTransitionMoves
		いろいろ壊れてる
	RivalAllSearch
		check_split_movesのresize
		ret.size()が10未満の場合もある
	AllyAllSearch
		check_split_moves.resize